### PR TITLE
Use Obsidian font as default

### DIFF
--- a/data/init/init.txt
+++ b/data/init/init.txt
@@ -27,7 +27,7 @@ If set below 256x256 it specifies the grid size instead, with a minimum of 80x25
 
 [WINDOWEDX:0]
 [WINDOWEDY:0]
-[FONT:text_12x16.png]
+[FONT:Obsidian_16x16_df40.png]
 
 You may disable window resizing if you wish.
 [RESIZABLE:YES]
@@ -36,7 +36,7 @@ Full screen info.  The 0s below mean that the game will choose a resolution for 
 
 [FULLSCREENX:0]
 [FULLSCREENY:0]
-[FULLFONT:text_12x16.png]
+[FULLFONT:Obsidian_16x16_df40.png]
 
 If this is set to NO, tiles will be stretched to fit the screen if there is a resolution mismatch.
 If this is set to YES, the tiles will not be stretched, but rather the game view will be centralized, surrounded by black space.  Tiles that are too large will always be compressed rather than running off the screen.


### PR DESCRIPTION
if used with LNP, LNP will use the default text font rather than the obsidian package unless FONT/FULLFONT are updated
